### PR TITLE
RL-6119: update latest version of action

### DIFF
--- a/.github/workflows/lockdown.yml
+++ b/.github/workflows/lockdown.yml
@@ -14,7 +14,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/repo-lockdown@v2
+      - uses: dessant/repo-lockdown@v3
         with:
           github-token: ${{ github.token }}
           pr-comment: 'Please create a PR against your own repository. Thank you.'


### PR DESCRIPTION
**Problem:** 
We are using an old GitHub Node and per GitHub all Actions will begin running on Node16 “Summer of 2023”. We need to update node based repos.

**Solution:**
To fix the warning I had to update the actions:
`dessant/repo-lockdown@v3`

**Link:**
[Github actions](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
)
[Jira ticket](https://remotelock.atlassian.net/browse/RL-6119)